### PR TITLE
Making the Maze class available for import.

### DIFF
--- a/maze/df_maze.py
+++ b/maze/df_maze.py
@@ -1,6 +1,7 @@
 # df_maze.py
 import random
 
+
 # Create a maze using the depth-first algorithm described at
 # https://scipython.com/blog/making-a-maze/
 # Christian Hill, April 2017.
@@ -33,6 +34,7 @@ class Cell:
         self.walls[wall] = False
         other.walls[Cell.wall_pairs[wall]] = False
 
+
 class Maze:
     """A Maze, represented as a grid of cells."""
 
@@ -55,17 +57,17 @@ class Maze:
     def __str__(self):
         """Return a (crude) string representation of the maze."""
 
-        maze_rows = ['-' * nx*2]
-        for y in range(ny):
+        maze_rows = ['-' * self.nx * 2]
+        for y in range(self.ny):
             maze_row = ['|']
-            for x in range(nx):
+            for x in range(self.nx):
                 if self.maze_map[x][y].walls['E']:
                     maze_row.append(' |')
                 else:
                     maze_row.append('  ')
             maze_rows.append(''.join(maze_row))
             maze_row = ['|']
-            for x in range(nx):
+            for x in range(self.nx):
                 if self.maze_map[x][y].walls['S']:
                     maze_row.append('-+')
                 else:
@@ -83,13 +85,13 @@ class Maze:
         height = 500
         width = int(height * aspect_ratio)
         # Scaling factors mapping maze coordinates to image coordinates
-        scy, scx = height / ny, width / nx
+        scy, scx = height / self.ny, width / self.nx
 
-        def write_wall(f, x1, y1, x2, y2):
+        def write_wall(ww_f, ww_x1, ww_y1, ww_x2, ww_y2):
             """Write a single wall to the SVG image file handle f."""
 
             print('<line x1="{}" y1="{}" x2="{}" y2="{}"/>'
-                                .format(x1, y1, x2, y2), file=f)
+                  .format(ww_x1, ww_y1, ww_x2, ww_y2), file=ww_f)
 
         # Write the SVG image file for maze
         with open(filename, 'w') as f:
@@ -98,8 +100,8 @@ class Maze:
             print('<svg xmlns="http://www.w3.org/2000/svg"', file=f)
             print('    xmlns:xlink="http://www.w3.org/1999/xlink"', file=f)
             print('    width="{:d}" height="{:d}" viewBox="{} {} {} {}">'
-                    .format(width+2*padding, height+2*padding,
-                        -padding, -padding, width+2*padding, height+2*padding),
+                  .format(width + 2 * padding, height + 2 * padding,
+                          -padding, -padding, width + 2 * padding, height + 2 * padding),
                   file=f)
             print('<defs>\n<style type="text/css"><![CDATA[', file=f)
             print('line {', file=f)
@@ -109,32 +111,32 @@ class Maze:
             # Draw the "South" and "East" walls of each cell, if present (these
             # are the "North" and "West" walls of a neighbouring cell in
             # general, of course).
-            for x in range(nx):
-                for y in range(ny):
-                    if maze.cell_at(x,y).walls['S']:
-                        x1, y1, x2, y2 = x*scx, (y+1)*scy, (x+1)*scx, (y+1)*scy
+            for x in range(self.nx):
+                for y in range(self.ny):
+                    if self.cell_at(x, y).walls['S']:
+                        x1, y1, x2, y2 = x * scx, (y + 1) * scy, (x + 1) * scx, (y + 1) * scy
                         write_wall(f, x1, y1, x2, y2)
-                    if maze.cell_at(x,y).walls['E']:
-                        x1, y1, x2, y2 = (x+1)*scx, y*scy, (x+1)*scx, (y+1)*scy
+                    if self.cell_at(x, y).walls['E']:
+                        x1, y1, x2, y2 = (x + 1) * scx, y * scy, (x + 1) * scx, (y + 1) * scy
                         write_wall(f, x1, y1, x2, y2)
             # Draw the North and West maze border, which won't have been drawn
-            # by the procedure above. 
+            # by the procedure above.
             print('<line x1="0" y1="0" x2="{}" y2="0"/>'.format(width), file=f)
-            print('<line x1="0" y1="0" x2="0" y2="{}"/>'.format(height),file=f)
+            print('<line x1="0" y1="0" x2="0" y2="{}"/>'.format(height), file=f)
             print('</svg>', file=f)
 
     def find_valid_neighbours(self, cell):
         """Return a list of unvisited neighbours to cell."""
 
-        delta = [('W', (-1,0)),
-                 ('E', (1,0)),
-                 ('S', (0,1)),
-                 ('N', (0,-1))]
+        delta = [('W', (-1, 0)),
+                 ('E', (1, 0)),
+                 ('S', (0, 1)),
+                 ('N', (0, -1))]
         neighbours = []
-        for direction, (dx,dy) in delta:
+        for direction, (dx, dy) in delta:
             x2, y2 = cell.x + dx, cell.y + dy
-            if (0 <= x2 < nx) and (0 <= y2 < ny):
-                neighbour = maze.cell_at(x2, y2)
+            if (0 <= x2 < self.nx) and (0 <= y2 < self.ny):
+                neighbour = self.cell_at(x2, y2)
                 if neighbour.has_all_walls():
                     neighbours.append((direction, neighbour))
         return neighbours
@@ -143,7 +145,7 @@ class Maze:
         # Total number of cells.
         n = self.nx * self.ny
         cell_stack = []
-        current_cell = self.cell_at(ix, iy)
+        current_cell = self.cell_at(self.ix, self.iy)
         # Total number of visited cells during maze construction.
         nv = 1
 
@@ -162,6 +164,12 @@ class Maze:
             current_cell = next_cell
             nv += 1
 
+
+"""
+# Example usage:
+
+from df_maze import *
+
 # Maze dimensions (ncols, nrows)
 nx, ny = 15, 15
 # Maze entry position
@@ -172,5 +180,4 @@ maze.make_maze()
 
 print(maze)
 maze.write_svg('maze.svg')
-
-
+"""


### PR DESCRIPTION
The Maze class was making references to variables outside its local scope which made it unavailable for imports. This was fixed by changing the calls to "self." versions (nx, ny, ix, iy).

There was also calls to local methods as class methods which were also fixed by changing to "self." (maze.cell_at() -> self.cell_at()).

In the write_wall() method, the variable names were shadowing outer scope variable names, so these were also fixed by prefixing "ww_" (f, x1, y1, x2, y2).

The demonstration code at the end was commented out to reflect the import case (as a separate file).

Last (and least), a couple of space formatting were applied within PEP recommendations.